### PR TITLE
Expand test coverage for CLI utilities and API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pydantic
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,16 +7,34 @@ from fastapi.testclient import TestClient
 import api
 def test_health_and_videos(tmp_path):
     with TestClient(api.app) as client:
+        # Health endpoint test
         r = client.get("/health")
         assert r.status_code == 200
         data = r.json()
         assert data["ok"] is True
+
+        # /videos with one video file
         (tmp_path / "v.mp4").write_bytes(b"00")
         r = client.get("/videos", params={"directory": str(tmp_path)})
         assert r.status_code == 200
         body = r.json()
         assert body["count"] == 1
         assert any(Path(p).name == "v.mp4" for p in body["videos"])
+
+        # /videos with empty directory
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        r = client.get("/videos", params={"directory": str(empty_dir)})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 0
+        assert body["videos"] == []
+
+        # /videos with invalid/non-existent directory
+        invalid_dir = tmp_path / "does_not_exist"
+        r = client.get("/videos", params={"directory": str(invalid_dir)})
+        # Expecting 400 or 404 depending on API implementation, adjust as needed
+        assert r.status_code in (400, 404)
 
 
 def test_job_meta_and_report(tmp_path, monkeypatch):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,10 @@
 import time
-import sys
-from pathlib import Path
+
+
 
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import api
-
-
 def test_health_and_videos(tmp_path):
     with TestClient(api.app) as client:
         r = client.get("/health")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,40 @@
+import time
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import api
+
+
+def test_health_and_videos(tmp_path):
+    with TestClient(api.app) as client:
+        r = client.get("/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is True
+        (tmp_path / "v.mp4").write_bytes(b"00")
+        r = client.get("/videos", params={"directory": str(tmp_path)})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+        assert any(Path(p).name == "v.mp4" for p in body["videos"])
+
+
+def test_job_meta(tmp_path, monkeypatch):
+    monkeypatch.setenv("FFPROBE_DISABLE", "1")
+    (tmp_path / "v.mp4").write_bytes(b"00")
+    with TestClient(api.app) as client:
+        payload = {"task": "meta", "directory": str(tmp_path), "recursive": False, "force": True, "params": {}}
+        r = client.post("/jobs", json=payload)
+        assert r.status_code == 200
+        job_id = r.json()["id"]
+        for _ in range(20):
+            r2 = client.get(f"/jobs/{job_id}")
+            if r2.json()["status"] == "done":
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError("job did not finish")
+    assert (tmp_path / "v.mp4.ffprobe.json").exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from index import parse_time_spec, human_size
+
+
+def test_parse_time_spec():
+    assert parse_time_spec("middle", 100.0) == 50.0
+    assert parse_time_spec("25%", 200.0) == 50.0
+    assert parse_time_spec("25%", None) == 1.0
+    assert parse_time_spec("10", None) == 10.0
+    assert parse_time_spec("bad", 0) == 1.0
+
+
+def test_human_size():
+    assert human_size(0) == "0.0B"
+    assert human_size(1024) == "1.0KB"
+    assert human_size(1024 * 1024) == "1.0MB"
+    assert human_size(-1) == "?"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,6 @@ import math
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
 from index import parse_time_spec, human_size
 
 


### PR DESCRIPTION
## Summary
- Add httpx dependency and move tests into dedicated `tests/` directory
- Extend CLI tests with queue handling, size sorting, and stubbed artifact generation
- Add unit tests for utility helpers
- Add FastAPI endpoint and job execution tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa15b2a4a8833098c3c6e5f9f0f8e2

## Summary by Sourcery

Expand test coverage by reorganizing tests and adding new CLI utility, API endpoint, and helper function tests

Enhancements:
- Move existing tests into a dedicated tests/ directory and update CLI test paths

Build:
- Add httpx to project dependencies for HTTP testing support

Tests:
- Add CLI tests for queue handling in stub mode
- Add CLI tests for file listing sorted by size with human-readable output
- Add unit tests for utility helpers parse_time_spec and human_size
- Add API tests for health and videos endpoints
- Add API job execution tests for meta tasks with polling