### PR TITLE
Add face clustering utility and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ python index.py codecs [dir] [-r] [--target-v h264] [--target-a aac] [--allowed-
 python index.py transcode [dir] dest [-r] [--target-v h264] [--target-a aac] [--crf 28] [--v-bitrate 3000k] [--a-bitrate 128k] [--preset medium] [--hardware none|videotoolbox] [--drop-subs] [--workers 1] [--force] [--dry-run] [--output-format json|text]
 python index.py compare original.mp4 other.mp4 [--output-format json|text]
 python index.py report [dir] [-r] [--output-format json|text]
+python index.py faces [dir] [-r] [--frame-rate 1.0] [--eps 0.5] [--min-samples 2] [--output faces.json]
 ```
 
 `list`:
@@ -70,10 +71,15 @@ python index.py report [dir] [-r] [--output-format json|text]
 	Batch transcode incompatible (or all with `--force`) videos into a normalized MP4 (default H.264 + AAC) tree mirroring source structure. Supports CRF/preset software encoders and optional VideoToolbox hardware acceleration. Dry-run mode plans actions without encoding.
 
 `compare`:
-	Compute SSIM and PSNR between two files (original vs other) and classify quality levels.
+        Compute SSIM and PSNR between two files (original vs other) and classify quality levels.
 
 `report`:
-	Summarize library artifact coverage: counts & percentages for metadata, thumbnail, sprites, previews, subtitles, phash, heatmap, scenes. Outputs per-file presence matrix (JSON mode) or a concise table (text mode).
+        Summarize library artifact coverage: counts & percentages for metadata, thumbnail, sprites, previews, subtitles, phash, heatmap, scenes. Outputs per-file presence matrix (JSON mode) or a concise table (text mode).
+
+`faces`:
+        Detect faces, generate embeddings and cluster recurring faces using DBSCAN. Outputs JSON mapping of cluster IDs to occurrences (video name, timestamp, bounding box) for later manual labeling.
+        Requires `opencv-python`, `face_recognition`, and `scikit-learn`.
+
 
 Set `FFPROBE_DISABLE=1` to produce stub metadata JSON without calling ffprobe (useful on systems lacking ffprobe or for tests).
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/faces.py
+++ b/faces.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Dict, List, Any
+
+
+def cluster_faces(
+    videos: Iterable[Path],
+    frame_rate: float = 1.0,
+    eps: float = 0.5,
+    min_samples: int = 2,
+) -> Dict[int, List[Dict[str, Any]]]:
+    """Detect faces in ``videos`` and cluster them by similarity.
+
+    Parameters
+    ----------
+    videos:
+        Iterable of video file paths.
+    frame_rate:
+        Frames per second to sample for detection.
+    eps, min_samples:
+        Parameters passed to :class:`sklearn.cluster.DBSCAN`.
+
+    Returns
+    -------
+    dict
+        Mapping of cluster id to list of occurrences. Each occurrence contains
+        ``video`` name, ``timestamp`` in seconds and ``bbox`` dictionary with
+        ``top``, ``right``, ``bottom`` and ``left`` coordinates.
+    """
+    try:
+        import cv2
+        import numpy as np
+        from sklearn.cluster import DBSCAN
+        import face_recognition
+    except Exception as exc:  # pragma: no cover - heavy optional deps
+        raise RuntimeError(
+            "face clustering requires cv2, face_recognition and scikit-learn"
+        ) from exc
+
+    embeddings: List[np.ndarray] = []
+    occurrences: List[Dict[str, Any]] = []
+
+    for video in videos:
+        cap = cv2.VideoCapture(str(video))
+        if not cap.isOpened():
+            cap.release()
+            continue
+        fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+        step = max(int(round(fps / frame_rate)), 1)
+        frame_idx = 0
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            if frame_idx % step == 0:
+                rgb = frame[:, :, ::-1]
+                boxes = face_recognition.face_locations(rgb)
+                if boxes:
+                    encs = face_recognition.face_encodings(rgb, boxes)
+                    ts = frame_idx / fps
+                    for (top, right, bottom, left), enc in zip(boxes, encs):
+                        embeddings.append(enc)
+                        occurrences.append(
+                            {
+                                "video": video.name,
+                                "timestamp": ts,
+                                "bbox": {
+                                    "top": int(top),
+                                    "right": int(right),
+                                    "bottom": int(bottom),
+                                    "left": int(left),
+                                },
+                            }
+                        )
+            frame_idx += 1
+        cap.release()
+
+    if not embeddings:
+        return {}
+
+    data = np.vstack(embeddings)
+    norms = np.linalg.norm(data, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    normalized = data / norms
+
+    labels = DBSCAN(eps=eps, min_samples=min_samples, metric="euclidean").fit_predict(
+        normalized
+    )
+
+    clusters: Dict[int, List[Dict[str, Any]]] = {}
+    for label, occ in zip(labels, occurrences):
+        clusters.setdefault(int(label), []).append(occ)
+    return clusters

--- a/index.py
+++ b/index.py
@@ -1426,6 +1426,14 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     rpt.add_argument("-r", "--recursive", action="store_true")
     rpt.add_argument("--output-format", choices=["json","text"], default="text")
 
+    fc = sub.add_parser("faces", help="Detect and cluster faces across videos")
+    fc.add_argument("directory", nargs="?", default=".")
+    fc.add_argument("-r", "--recursive", action="store_true")
+    fc.add_argument("--frame-rate", type=float, default=1.0, help="Frames per second to sample")
+    fc.add_argument("--eps", type=float, default=0.5, help="DBSCAN eps parameter")
+    fc.add_argument("--min-samples", type=int, default=2, help="DBSCAN min samples")
+    fc.add_argument("--output", default=None, help="Write JSON result to file")
+
     return p.parse_args(argv)
 
 
@@ -2135,6 +2143,27 @@ def cmd_compare(ns) -> int:
     return 0
 
 
+def cmd_faces(ns) -> int:
+    root = Path(ns.directory).expanduser().resolve()
+    if not root.is_dir():
+        print(f"Error: directory not found: {root}", file=sys.stderr)
+        return 2
+    videos = find_mp4s(root, ns.recursive)
+    from faces import cluster_faces
+    clusters = cluster_faces(
+        videos,
+        frame_rate=ns.frame_rate,
+        eps=ns.eps,
+        min_samples=ns.min_samples,
+    )
+    text = json.dumps(clusters, indent=2)
+    if ns.output:
+        Path(ns.output).write_text(text)
+    else:
+        print(text)
+    return 0
+
+
 def cmd_report(ns) -> int:
     root = Path(ns.directory).expanduser().resolve()
     if not root.is_dir():
@@ -2266,6 +2295,8 @@ def main(argv: List[str] | None = None) -> int:
         return cmd_heatmap(ns)
     if ns.cmd == "scenes":
         return cmd_scenes(ns)
+    if ns.cmd == "faces":
+        return cmd_faces(ns)
     if ns.cmd == "codecs":
         return cmd_codecs(ns)
     if ns.cmd == "transcode":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,5 @@
 import time
-
-
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- implement `cluster_faces` to detect faces across multiple videos, normalize embeddings and cluster with DBSCAN
- add `faces` CLI command to invoke clustering and write JSON mapping of cluster IDs to occurrences
- document the new `faces` command in the README, including dependency notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad65540f68833098af652702cfaf6b

## Summary by Sourcery

Introduce face clustering functionality and expose it via a new CLI command

New Features:
- Add cluster_faces utility to detect, normalize embeddings, and cluster faces using DBSCAN
- Add faces subcommand in index.py to invoke face clustering with configurable parameters and output options

Documentation:
- Update README with faces command usage and note required dependencies

Tests:
- Add conftest.py to include project root in sys.path for test discovery