### PR TITLE
Return structured video info

### DIFF
--- a/api.py
+++ b/api.py
@@ -445,7 +445,8 @@ def list_videos(request: Request, directory: str = Query("."), recursive: bool =
         {"path": str(p), "name": p.name, "size": p.stat().st_size} for p in slice_v
     ]
     if detail:
-        for info, p in zip(videos_out, slice_v):
+        for i, info in enumerate(videos_out):
+            p = slice_v[i]
             # tags
             tfile = index.artifact_dir(p) / f"{p.stem}.tags.json"
             if tfile.exists():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,9 @@ def test_health_and_videos(tmp_path):
         assert r.status_code == 200
         body = r.json()
         assert body["count"] == 1
-        assert any(Path(p).name == "v.mp4" for p in body["videos"])
+        assert any(v["name"] == "v.mp4" for v in body["videos"])
+        for v in body["videos"]:
+            assert {"path", "name", "size"} <= v.keys()
 
         # /videos with empty directory
         empty_dir = tmp_path / "empty"


### PR DESCRIPTION
## Summary
- Ensure `/videos` returns structured objects with path, name, and size
- Support optional metadata enrichment when `detail` flag is set
- Adjust API tests for new video object structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b26f89d2948330b45271de0ff3963a

## Summary by Sourcery

Change the /videos endpoint to return structured video details by default and apply optional enrichment when requested, with corresponding test updates.

New Features:
- Return video entries as structured objects containing path, name, and size

Enhancements:
- Support conditional enrichment of additional metadata when the detail flag is provided
- Inline metadata augmentation instead of building a separate detailed list

Tests:
- Update API tests to validate that each video object includes path, name, and size keys