### PR TITLE
Add paginated video list with sorting and infinite scroll

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -46,3 +46,203 @@ class Router {
 }
 
 window.Router = Router;
+
+// ---------------------------------------------------------------------------
+// Video listing with pagination, sorting, and optional infinite scrolling
+// ---------------------------------------------------------------------------
+
+const state = {
+  page: 1,
+  perPage: 16,
+  sort: { column: 'title', dir: 'asc' },
+  total: 0,
+  infinite: false,
+  loading: false,
+};
+
+function formatDuration(sec) {
+  if (!sec && sec !== 0) return '';
+  const s = Math.floor(sec % 60).toString().padStart(2, '0');
+  const m = Math.floor((sec / 60) % 60).toString().padStart(2, '0');
+  const h = Math.floor(sec / 3600);
+  return h ? `${h}:${m}:${s}` : `${m}:${s}`;
+}
+
+function formatSize(bytes) {
+  if (!bytes && bytes !== 0) return '';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let i = 0;
+  let num = bytes;
+  while (num >= 1024 && i < units.length - 1) {
+    num /= 1024;
+    i += 1;
+  }
+  return `${num.toFixed(1)} ${units[i]}`;
+}
+
+const columns = [
+  { key: 'title', label: 'Title', get: v => v.name || v.title || '' },
+  { key: 'duration', label: 'Duration', get: v => v.duration || 0, fmt: v => formatDuration(v.duration) },
+  {
+    key: 'resolution',
+    label: 'Resolution',
+    get: v => v.resolution || (v.width && v.height ? `${v.width}x${v.height}` : ''),
+  },
+  {
+    key: 'added',
+    label: 'Date added',
+    get: v => v.added || v.video_mtime || v.mtime || 0,
+    fmt: v => (v.added || v.video_mtime || v.mtime ? new Date((v.added || v.video_mtime || v.mtime) * 1000).toLocaleString() : ''),
+  },
+  { key: 'plays', label: 'Plays', get: v => v.plays || 0 },
+  { key: 'codec', label: 'Codec', get: v => v.vcodec || v.codec || '' },
+  { key: 'size', label: 'File size', get: v => v.size || 0, fmt: v => formatSize(v.size) },
+];
+
+async function listVideos(params = {}) {
+  const url = new URL('/videos', window.location);
+  const offset = params.offset || 0;
+  const limit = params.limit || state.perPage;
+  url.searchParams.set('offset', offset);
+  url.searchParams.set('limit', limit);
+  url.searchParams.set('detail', '1');
+  const resp = await fetch(url.toString());
+  if (!resp.ok) throw new Error('Failed to load videos');
+  return resp.json();
+}
+
+function sortVideos(videos) {
+  const { column, dir } = state.sort;
+  const col = columns.find(c => c.key === column);
+  if (!col) return videos;
+  const factor = dir === 'asc' ? 1 : -1;
+  return videos.sort((a, b) => {
+    const va = col.get(a);
+    const vb = col.get(b);
+    if (typeof va === 'number' && typeof vb === 'number') {
+      return (va - vb) * factor;
+    }
+    return String(va).localeCompare(String(vb)) * factor;
+  });
+}
+
+function buildHeader(table) {
+  if (table.tHead) return;
+  const thead = table.createTHead();
+  const row = thead.insertRow();
+  columns.forEach(col => {
+    const th = document.createElement('th');
+    th.textContent = col.label;
+    th.dataset.key = col.key;
+    th.addEventListener('click', () => {
+      if (state.sort.column === col.key) {
+        state.sort.dir = state.sort.dir === 'asc' ? 'desc' : 'asc';
+      } else {
+        state.sort.column = col.key;
+        state.sort.dir = 'asc';
+      }
+      renderList(true);
+    });
+    row.appendChild(th);
+  });
+}
+
+function clearBody(table) {
+  if (table.tBodies.length) {
+    table.removeChild(table.tBodies[0]);
+  }
+}
+
+function appendRows(table, videos) {
+  const tbody = table.tBodies[0] || table.createTBody();
+  videos.forEach(v => {
+    const tr = tbody.insertRow();
+    columns.forEach(col => {
+      const td = tr.insertCell();
+      const raw = col.get(v);
+      td.textContent = col.fmt ? col.fmt(v) : raw;
+    });
+  });
+}
+
+async function renderList(reset = false) {
+  if (state.loading) return;
+  state.loading = true;
+  if (reset) {
+    state.page = 1;
+    const table = document.getElementById('video-table');
+    clearBody(table);
+  }
+  const offset = (state.page - 1) * state.perPage;
+  const data = await listVideos({ offset, limit: state.perPage });
+  state.total = data.count || 0;
+  let vids = data.videos || [];
+  vids = sortVideos(vids);
+  const table = document.getElementById('video-table');
+  buildHeader(table);
+  appendRows(table, vids);
+  updatePagination();
+  state.loading = false;
+}
+
+function updatePagination() {
+  const pag = document.getElementById('pagination');
+  if (!pag) return;
+  if (state.infinite) {
+    pag.style.display = 'none';
+    return;
+  }
+  pag.style.display = 'block';
+  const pages = Math.max(1, Math.ceil(state.total / state.perPage));
+  const info = document.getElementById('page-info');
+  info.textContent = `Page ${state.page} of ${pages}`;
+  const prev = document.getElementById('prev-page');
+  const next = document.getElementById('next-page');
+  prev.disabled = state.page <= 1;
+  next.disabled = state.page >= pages;
+}
+
+function handleScroll() {
+  if (!state.infinite || state.loading) return;
+  if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 50) {
+    const maxPages = Math.ceil(state.total / state.perPage);
+    if (state.page < maxPages) {
+      state.page += 1;
+      renderList(false);
+    }
+  }
+}
+
+window.addEventListener('load', () => {
+  const prev = document.getElementById('prev-page');
+  const next = document.getElementById('next-page');
+  if (prev && next) {
+    prev.addEventListener('click', () => {
+      if (state.page > 1) {
+        state.page -= 1;
+        renderList(true);
+      }
+    });
+    next.addEventListener('click', () => {
+      const pages = Math.ceil(state.total / state.perPage);
+      if (state.page < pages) {
+        state.page += 1;
+        renderList(true);
+      }
+    });
+  }
+  const toggle = document.getElementById('infiniteToggle');
+  if (toggle) {
+    toggle.addEventListener('change', () => {
+      state.infinite = toggle.checked;
+      window.removeEventListener('scroll', handleScroll);
+      if (state.infinite) {
+        window.addEventListener('scroll', handleScroll);
+      }
+      renderList(true);
+    });
+  }
+  renderList(true);
+});
+
+window.renderList = renderList;

--- a/static/index.html
+++ b/static/index.html
@@ -9,7 +9,15 @@
   <nav>
     <a href="#/">Home</a>
   </nav>
-  <ul id="video-links"></ul>
+  <div id="settings">
+    <label><input type="checkbox" id="infiniteToggle"> Infinite scroll</label>
+  </div>
+  <table id="video-table"></table>
+  <div id="pagination">
+    <button id="prev-page">Prev</button>
+    <span id="page-info"></span>
+    <button id="next-page">Next</button>
+  </div>
   <div id="view"></div>
   <script>
     const router = new Router('view');
@@ -20,17 +28,7 @@
       .register('/videos/:id', ({id}) => {
         document.getElementById('view').textContent = `Viewing video ${id}`;
       });
-
-    const videos = ['alpha', 'beta', 'gamma'];
-    const list = document.getElementById('video-links');
-    videos.forEach(id => {
-      const li = document.createElement('li');
-      const a = document.createElement('a');
-      a.href = `#/videos/${encodeURIComponent(id)}`;
-      a.textContent = `Video ${id}`;
-      li.appendChild(a);
-      list.appendChild(li);
-    });
+    // Listing is initiated by app.js on load
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a renderList implementation that fetches videos, builds a sortable table and supports pagination
- support 16-item pages with optional infinite scroll toggle in settings
- update sample index to include table markup and controls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6137d223083308fa346c09cdce18c

## Summary by Sourcery

Introduce a paginated, sortable video list component with optional infinite scrolling and navigation controls, and update the sample index page to render this interface

New Features:
- Add a video list renderer that fetches videos, builds a sortable table, and supports pagination
- Support optional infinite scrolling via a toggle and handle scroll-based incremental loading
- Provide prev/next buttons and page info display for manual page navigation

Enhancements:
- Add formatDuration and formatSize helpers for human-readable duration and size
- Update index.html to include the video table markup, infinite scroll toggle, and pagination controls