### PR TITLE
Add editable metadata and rename endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -587,11 +587,14 @@ def get_video_tags(name: str, directory: str = Query(".")):
         raise HTTPException(404, "video not found")
     tfile = index.artifact_dir(path) / f"{path.stem}.tags.json"
     if not tfile.exists():
-        return {"video": name, "tags": [], "performers": []}
+        return {"video": name, "tags": [], "performers": [], "description": ""}
     try:
-        return json.loads(tfile.read_text())
+        data = json.loads(tfile.read_text())
     except Exception:
         raise HTTPException(500, "invalid tags file")
+    if "description" not in data:
+        data["description"] = ""
+    return data
 
 class TagUpdate(BaseModel):
     add: list[str] | None = None
@@ -599,6 +602,7 @@ class TagUpdate(BaseModel):
     performers_add: list[str] | None = None
     performers_remove: list[str] | None = None
     replace: bool = False
+    description: str | None = None
 
 @app.patch("/videos/{name}/tags")
 def update_video_tags(name: str, payload: TagUpdate, directory: str = Query(".")):
@@ -611,9 +615,10 @@ def update_video_tags(name: str, payload: TagUpdate, directory: str = Query(".")
         try:
             data = json.loads(tfile.read_text())
         except Exception:
-            data = {"video": name, "tags": [], "performers": []}
+            data = {"video": name, "tags": [], "performers": [], "description": ""}
     else:
-        data = {"video": name, "tags": [], "performers": []}
+        data = {"video": name, "tags": [], "performers": [], "description": ""}
+    data.setdefault("description", "")
     if payload.replace and payload.add is not None:
         data["tags"] = []
     if payload.add:
@@ -628,12 +633,36 @@ def update_video_tags(name: str, payload: TagUpdate, directory: str = Query(".")
                 data["performers"].append(t)
     if payload.performers_remove:
         data["performers"] = [t for t in data["performers"] if t not in payload.performers_remove]
+    if payload.description is not None:
+        data["description"] = payload.description
     # Write back
     try:
         tfile.write_text(json.dumps(data, indent=2))
     except Exception:
         raise HTTPException(500, "failed to write tags")
     return data
+
+
+class RenameRequest(BaseModel):
+    new_name: str
+
+
+@app.post("/videos/{name}/rename")
+def rename_video(name: str, payload: RenameRequest, directory: str = Query(".")):
+    root = Path(directory).expanduser().resolve()
+    src = root / name
+    dst = root / payload.new_name
+    if not src.exists():
+        raise HTTPException(404, "video not found")
+    if dst.exists():
+        raise HTTPException(409, "destination exists")
+    try:
+        index.rename_with_artifacts(src, dst)
+    except FileNotFoundError:
+        raise HTTPException(404, "video not found")
+    except Exception:
+        raise HTTPException(500, "rename failed")
+    return {"old_name": name, "new_name": payload.new_name}
 
 @app.get("/videos/{name}")
 def video_detail(name: str, directory: str = Query(".")):
@@ -652,12 +681,15 @@ def video_detail(name: str, directory: str = Query(".")):
             tdata = json.loads(tfile.read_text())
             info["tags"] = tdata.get("tags", [])
             info["performers"] = tdata.get("performers", [])
+            info["description"] = tdata.get("description", "")
         except Exception:
             info["tags"] = []
             info["performers"] = []
+            info["description"] = ""
     else:
         info["tags"] = []
         info["performers"] = []
+        info["description"] = ""
     # Duration/codecs via summary cache (single-file mode)
     try:
         summaries = index.load_metadata_summary(root, recursive=False)
@@ -711,6 +743,7 @@ def import_tags(payload: BulkImport, directory: str = Query(".")):
                 "video": name,
                 "tags": entry.get("tags", []),
                 "performers": entry.get("performers", []),
+                "description": entry.get("description", ""),
             }, indent=2))
             written += 1
         except Exception:

--- a/static/app.js
+++ b/static/app.js
@@ -56,6 +56,44 @@ class Router {
 
 window.Router = Router;
 
+// Simple toast helper
+function showToast(message, { duration = 3000, actionText, onAction } = {}) {
+  let container = document.getElementById('toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'toast-container';
+    container.style.position = 'fixed';
+    container.style.bottom = '10px';
+    container.style.right = '10px';
+    container.style.zIndex = '1000';
+    document.body.appendChild(container);
+  }
+  const toast = document.createElement('div');
+  toast.textContent = message;
+  toast.style.background = 'rgba(0,0,0,0.7)';
+  toast.style.color = 'white';
+  toast.style.padding = '8px 12px';
+  toast.style.marginTop = '5px';
+  toast.style.borderRadius = '4px';
+  if (actionText && typeof onAction === 'function') {
+    const btn = document.createElement('button');
+    btn.textContent = actionText;
+    btn.style.marginLeft = '8px';
+    btn.addEventListener('click', () => {
+      onAction();
+      if (toast.parentNode) toast.parentNode.removeChild(toast);
+    });
+    toast.appendChild(btn);
+  }
+  container.appendChild(toast);
+  if (duration > 0) {
+    setTimeout(() => {
+      if (toast.parentNode) toast.parentNode.removeChild(toast);
+    }, duration);
+  }
+  return toast;
+}
+
 // ---------------------------------------------------------------------------
 // Grid rendering helper
 // ---------------------------------------------------------------------------
@@ -439,22 +477,126 @@ window.renderList = renderList;
 // ---------------------------------------------------------------------------
 // Simple player renderer
 // ---------------------------------------------------------------------------
-function renderPlayer(name, options = {}) {
+async function renderPlayer(name, options = {}) {
   const { containerId = 'view' } = options;
   const container = document.getElementById(containerId);
   if (!container) return;
 
-  // Reset view and create basic player element
   container.innerHTML = '';
-  const title = document.createElement('h2');
-  title.textContent = name;
-  container.appendChild(title);
+  let currentName = name;
+
+  const titleInput = document.createElement('input');
+  titleInput.type = 'text';
+  titleInput.value = currentName;
+  container.appendChild(titleInput);
 
   const video = document.createElement('video');
   video.controls = true;
-  // Assume the server can serve raw video at this path
-  video.src = `/videos/${encodeURIComponent(name)}`;
+  video.src = `/videos/${encodeURIComponent(currentName)}`;
   container.appendChild(video);
+
+  let tagData = { tags: [], performers: [], description: '' };
+  try {
+    const resp = await fetch(`/videos/${encodeURIComponent(currentName)}/tags`);
+    if (resp.ok) {
+      const d = await resp.json();
+      tagData = {
+        tags: d.tags || [],
+        performers: d.performers || [],
+        description: d.description || '',
+      };
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  const descInput = document.createElement('textarea');
+  descInput.value = tagData.description || '';
+  container.appendChild(descInput);
+
+  const tagsInput = document.createElement('input');
+  tagsInput.type = 'text';
+  tagsInput.value = (tagData.tags || []).join(', ');
+  container.appendChild(tagsInput);
+
+  const perfInput = document.createElement('input');
+  perfInput.type = 'text';
+  perfInput.value = (tagData.performers || []).join(', ');
+  container.appendChild(perfInput);
+
+  function splitList(str) {
+    return str.split(',').map(s => s.trim()).filter(Boolean);
+  }
+
+  async function patchTags(payload, field) {
+    try {
+      const resp = await fetch(`/videos/${encodeURIComponent(currentName)}/tags`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!resp.ok) throw new Error('bad');
+      field.dataset.retry = '';
+      return true;
+    } catch (err) {
+      field.dataset.retry = '1';
+      showToast('Update failed');
+      return false;
+    }
+  }
+
+  descInput.addEventListener('blur', async () => {
+    const val = descInput.value;
+    if (descInput.dataset.retry !== '1' && val === tagData.description) return;
+    const ok = await patchTags({ description: val }, descInput);
+    if (ok) tagData.description = val;
+  });
+
+  tagsInput.addEventListener('blur', async () => {
+    const newTags = splitList(tagsInput.value);
+    if (tagsInput.dataset.retry !== '1' && newTags.join(',') === (tagData.tags || []).join(',')) return;
+    const ok = await patchTags({ replace: true, add: newTags }, tagsInput);
+    if (ok) tagData.tags = newTags;
+  });
+
+  perfInput.addEventListener('blur', async () => {
+    const newPerfs = splitList(perfInput.value);
+    if (perfInput.dataset.retry !== '1' && newPerfs.join(',') === (tagData.performers || []).join(',')) return;
+    const payload = { performers_remove: tagData.performers, performers_add: newPerfs };
+    const ok = await patchTags(payload, perfInput);
+    if (ok) tagData.performers = newPerfs;
+  });
+
+  async function renameVideo(oldName, newName, field) {
+    try {
+      const resp = await fetch(`/videos/${encodeURIComponent(oldName)}/rename`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ new_name: newName }),
+      });
+      if (!resp.ok) throw new Error('bad');
+      currentName = newName;
+      video.src = `/videos/${encodeURIComponent(newName)}`;
+      field.value = newName;
+      field.dataset.retry = '';
+      showToast(`Renamed to ${newName}`, {
+        duration: 10000,
+        actionText: 'Undo',
+        onAction: () => renameVideo(newName, oldName, field),
+      });
+      return true;
+    } catch (err) {
+      field.dataset.retry = '1';
+      showToast('Rename failed');
+      return false;
+    }
+  }
+
+  titleInput.addEventListener('blur', () => {
+    const newName = titleInput.value.trim();
+    if (!newName || (titleInput.dataset.retry !== '1' && newName === currentName)) return;
+    renameVideo(currentName, newName, titleInput);
+  });
 }
 
 window.renderPlayer = renderPlayer;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -186,6 +186,21 @@ def test_api_tags_endpoints(tmp_path, monkeypatch):
         assert not_mod.status_code == 304
 
 
+def test_api_rename_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setenv("FFPROBE_DISABLE", "1")
+    vid = tmp_path / "a.mp4"
+    vid.write_bytes(b"00")
+    art_dir = tmp_path / ".artifacts"
+    art_dir.mkdir()
+    (art_dir / "a.ffprobe.json").write_text("{}")
+    with TestClient(api.app) as client:
+        r = client.post(f"/videos/{vid.name}/rename", params={"directory": str(tmp_path)}, json={"new_name": "b.mp4"})
+        assert r.status_code == 200
+        assert (tmp_path / "b.mp4").exists()
+        assert (art_dir / "b.ffprobe.json").exists()
+        assert not vid.exists()
+
+
     def test_api_cancel_metadata_job(tmp_path, monkeypatch):
         monkeypatch.setenv("FFPROBE_DISABLE", "1")
         # Create many stub videos to keep job busy long enough to cancel


### PR DESCRIPTION
## Summary
- allow description updates and file renames via new API endpoints
- add rename endpoint test to ensure artifacts move
- enable player page editing for title, description, tags, and performers with toast feedback and undo

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba4de496408330984d9bebddc6d386