### PR TITLE
Add configurable settings with persistent theme support

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -766,7 +766,7 @@ async function renderPlayer(name, options = {}) {
         const resp = await fetch(`/videos/next?current=${encodeURIComponent(currentName)}`);
         if (resp.ok) {
           const data = await resp.json();
-          const next = data.next;
+          const {next} = data;
           if (next) {
             if (window.router instanceof Router) {
               window.router.navigate(`/video/${encodeURIComponent(next)}`);

--- a/static/app.js
+++ b/static/app.js
@@ -214,11 +214,18 @@ function renderSettings(options = {}) {
   sizeInput.type = 'number';
   sizeInput.min = '1';
   sizeInput.value = settings.listPageSize;
+  let prevValidPageSize = settings.listPageSize;
+
   sizeInput.addEventListener('change', () => {
     const v = parseInt(sizeInput.value, 10);
     if (!isNaN(v) && v > 0) {
       settings.listPageSize = v;
+      prevValidPageSize = v;
       saveSettings();
+    } else {
+      alert('Please enter a valid page size (number greater than 0).');
+      sizeInput.value = prevValidPageSize;
+    }
     }
   });
   addSection('List page size:', sizeInput);

--- a/static/index.html
+++ b/static/index.html
@@ -3,12 +3,26 @@
 <head>
   <meta charset="utf-8" />
   <title>Video Router Demo</title>
+  <script>
+    (function() {
+      try {
+        var s = JSON.parse(localStorage.getItem('settings') || '{}');
+        var t = s.theme || 'system';
+        var mode = t;
+        if (mode === 'system') {
+          mode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        document.documentElement.classList.add(mode === 'dark' ? 'theme-dark' : 'theme-light');
+      } catch (e) {}
+    })();
+  </script>
   <script src="app.js"></script>
 </head>
 <body>
   <nav>
     <a href="/" id="nav-home">Home</a>
     <a href="/report" id="nav-report">Artifacts</a>
+    <a href="/settings" id="nav-settings">Settings</a>
   </nav>
   <div id="view"></div>
   <script>
@@ -16,13 +30,20 @@
     window.router = new Router('view');
     router
       .register('/', () => {
-        renderGrid({ containerId: 'view' });
+        if (window.Settings && window.Settings.paging === 'list') {
+          renderList({ containerId: 'view' });
+        } else {
+          renderGrid({ containerId: 'view' });
+        }
       })
       .register('/video/:name', ({ name }) => {
         renderPlayer(name, { autoplay: true });
       })
       .register('/report', () => {
         renderReport({ containerId: 'view' });
+      })
+      .register('/settings', () => {
+        renderSettings({ containerId: 'view' });
       });
     document.getElementById('nav-home').addEventListener('click', e => {
       e.preventDefault();
@@ -31,6 +52,10 @@
     document.getElementById('nav-report').addEventListener('click', e => {
       e.preventDefault();
       router.navigate('/report');
+    });
+    document.getElementById('nav-settings').addEventListener('click', e => {
+      e.preventDefault();
+      router.navigate('/settings');
     });
 
     // Example static navigation; real app would query the API

--- a/static/index.html
+++ b/static/index.html
@@ -3,19 +3,6 @@
 <head>
   <meta charset="utf-8" />
   <title>Video Router Demo</title>
-  <script>
-    (function() {
-      try {
-        var s = JSON.parse(localStorage.getItem('settings') || '{}');
-        var t = s.theme || 'system';
-        var mode = t;
-        if (mode === 'system') {
-          mode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        }
-        document.documentElement.classList.add(mode === 'dark' ? 'theme-dark' : 'theme-light');
-      } catch (e) {}
-    })();
-  </script>
   <script src="app.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add persistent Settings management with theme, paging mode, page size and auto-advance
- Implement Settings UI with reset and localStorage persistence
- Apply theme before render and add Settings navigation and routing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba5447f8ec833084e974871ae098f9

## Summary by Sourcery

Introduce a persistent settings system with UI and routing, apply theme early, and adapt paging, page size, infinite scrolling, and auto-advance behavior according to user preferences

New Features:
- Persist user settings (theme, paging mode, page size, auto-advance, infinite scroll) to localStorage
- Add Settings UI with controls to modify preferences and reset to defaults
- Add Settings navigation link and route to access the settings page
- Load and apply theme on initial page load and react to system theme changes

Enhancements:
- Use stored page size and infinite scroll setting in list rendering
- Switch between grid and list views based on user paging mode
- Conditionally enable auto-advance in the video player based on settings