### PR TITLE
Enhance grid viewer interactions

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -421,9 +421,14 @@ async function renderGrid(options = {}) {
   observer.observe(sentinel);
 
   await appendBatch();
-  while (!done && sentinel.getBoundingClientRect().top <= window.innerHeight + 200) {
-    await appendBatch();
+  // Instead of a synchronous while loop, use a non-blocking batch loader.
+  async function loadBatches() {
+    if (!done && sentinel.getBoundingClientRect().top <= window.innerHeight + 200) {
+      await appendBatch();
+      setTimeout(loadBatches, 0); // Yield control to the browser between batches
+    }
   }
+  loadBatches();
 }
 
 window.renderGrid = renderGrid;

--- a/static/app.js
+++ b/static/app.js
@@ -118,7 +118,16 @@ function openSidebar(video) {
     sidebar.style.padding = '10px';
     document.body.appendChild(sidebar);
   }
-  sidebar.innerHTML = `<h3>${video.name}</h3>`;
+  sidebar.innerHTML = `
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+      <h3 style="margin: 0;">${video.name}</h3>
+      <button id="sidebar-close-btn" style="background: transparent; color: white; border: none; font-size: 1.5em; cursor: pointer;">&times;</button>
+    </div>
+  `;
+  const closeBtn = sidebar.querySelector('#sidebar-close-btn');
+  closeBtn.addEventListener('click', () => {
+    sidebar.remove();
+  });
 }
 
 window.openSidebar = openSidebar;


### PR DESCRIPTION
## Summary
- Show preview clips with play overlay when hovering over grid items
- Single click opens sidebar; double click or Enter starts playback
- Load more items via IntersectionObserver as user nears bottom

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb229a0bac8330a1f80faba558f8b3

## Summary by Sourcery

Enhance the grid viewer by adding a sidebar preview on single click and replacing scroll-based loading with an IntersectionObserver-driven infinite scroll.

New Features:
- Add openSidebar function to show video details in a fixed sidebar on single click
- Implement infinite loading of grid items via an IntersectionObserver sentinel

Enhancements:
- Update tile handlers so double click or Enter starts playback
- Ensure initial grid batches fill the viewport before stopping
- Disconnect observer and remove sentinel when all items are loaded