### PR TITLE
feat: add FaceLab exploration panel

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -26,6 +26,7 @@
     <a href="/stats" id="nav-stats">Stats</a>
     <a href="/report" id="nav-report">Artifacts</a>
     <a href="/settings" id="nav-settings">Settings</a>
+    <a href="/facelab" id="nav-facelab">FaceLab</a>
   </nav>
   <div id="view"></div>
   <script>
@@ -50,6 +51,9 @@
       })
       .register('/settings', () => {
         renderSettings({ containerId: 'view' });
+      })
+      .register('/facelab', () => {
+        renderFaceLab({ containerId: 'view' });
       });
     document.getElementById('nav-home').addEventListener('click', e => {
       e.preventDefault();
@@ -66,6 +70,10 @@
     document.getElementById('nav-settings').addEventListener('click', e => {
       e.preventDefault();
       router.navigate('/settings');
+    });
+    document.getElementById('nav-facelab').addEventListener('click', e => {
+      e.preventDefault();
+      router.navigate('/facelab');
     });
 
     // Example static navigation; real app would query the API


### PR DESCRIPTION
## Summary
- add FaceLab renderer with gallery, scatter, and cluster controls
- expose FaceLab route and navigation link
- support face label assignment and basic merge/split API endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd44c66240833099cb7872b20dc9f9

## Summary by Sourcery

Add an interactive FaceLab feature for visualizing and managing face embeddings by introducing a dedicated UI panel, navigation route, and backend endpoints for face label assignment, merge, and split operations.

New Features:
- Add FaceLab exploration panel with gallery, scatterplot, and cluster controls
- Expose FaceLab route and navigation link in the main UI
- Implement API endpoints for face label assignment, merging, and splitting

Enhancements:
- Integrate in-memory face label storage into the face listing endpoint