### PR TITLE
feat: add clipper workflow

### DIFF
--- a/api.py
+++ b/api.py
@@ -457,7 +457,7 @@ class JobExecutor(threading.Thread):
             dest = Path(params.get("dest") or (src.parent / "_clips"))
             fmt = params.get("format", "mp4")
             dest.mkdir(parents=True, exist_ok=True)
-            out_files: list[str] = []
+            out_files: List[str] = []
             with _jobs_lock:
                 job = _jobs.get(self.job_id)
                 if job:

--- a/static/app.js
+++ b/static/app.js
@@ -902,8 +902,13 @@ async function renderPlayer(name, options = {}) {
 
   function updateClipSel() {
     if (clipStart != null && clipEnd != null && video.duration) {
-      const s = (clipStart / video.duration) * 100;
-      const e = (clipEnd / video.duration) * 100;
+      let start = clipStart;
+      let end = clipEnd;
+      if (start > end) {
+        [start, end] = [end, start];
+      }
+      const s = (start / video.duration) * 100;
+      const e = (end / video.duration) * 100;
       clipSel.style.display = 'block';
       clipSel.style.left = `${s}%`;
       clipSel.style.width = `${e - s}%`;

--- a/static/index.html
+++ b/static/index.html
@@ -43,6 +43,12 @@
       .register('/video/:name', ({ name }) => {
         renderPlayer(name, { autoplay: true });
       })
+      .register('/clipper/:name', ({ name }) => {
+        const qs = new URLSearchParams(window.location.search);
+        const s = parseFloat(qs.get('start'));
+        const e = parseFloat(qs.get('end'));
+        renderClipper(name, { containerId: 'view', start: isNaN(s) ? null : s, end: isNaN(e) ? null : e });
+      })
       .register('/stats', () => {
         renderStats({ containerId: 'view' });
       })


### PR DESCRIPTION
## Summary
- add clip task to API job queue and implement basic ffmpeg-based clipping
- embed mini clipper controls on player timeline
- create clipper workspace UI with range management and export

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd45d9fb908330b9fdda0debd02f6f

## Summary by Sourcery

Introduce a clipper workflow by adding a new clip task to the API, integrating mini and full-featured clipping interfaces in the client, and validating the functionality with a dedicated test.

New Features:
- add clip task to job queue with ffmpeg-based clipping of specified ranges
- embed mini clipping controls on the video player timeline
- implement full clipper workspace UI for range selection and export

Enhancements:
- extend job tracker to accept onComplete callback for custom post-job behavior
- register clipper route in client-side router

Tests:
- add API test for the clip job end-to-end flow